### PR TITLE
added those missing responses

### DIFF
--- a/scripts/steward.coffee
+++ b/scripts/steward.coffee
@@ -19,6 +19,8 @@
 #   riveramj
 #   arigoldx
 
+Util = require 'util'
+
 GITHUB_TOKEN = process.env['GITHUB_TOKEN']
 ORGANIZATION = process.env['STEWARD_ORGANIZATION']
 
@@ -94,5 +96,10 @@ module.exports = (robot) ->
                         " #{file.filename} in #{repo}. The PR was #{action}."
                       robot.send envelope, message
 
+        else
+
+      res.send 200, "Received POST for pull request #{number}"
+
     catch exception
       console.log "It's all gone wrong:", exception, exception.stack
+      res.send 500, "It's all gone wrong: #{Util.inspect exception}"


### PR DESCRIPTION
Basically I'm returning 500 if we can't extract any of what ***should*** be there according to the Github docs.

And 200 otherwise.

The [webhook settings](https://github.com/elemica/mercury/settings/hooks) page is looking good:
![webhooks](https://cloud.githubusercontent.com/assets/1505339/5945261/038f10c0-a6e2-11e4-93ca-a9f2637203b1.png).

@Shadowfiend @riveramj 